### PR TITLE
레포별 install-settings 실행시 exit code relay

### DIFF
--- a/install.exp
+++ b/install.exp
@@ -21,3 +21,7 @@ expect {
                 exp_continue
         }
 }
+
+foreach {pid spawnid os_error_flag value} [wait] break
+puts "Exit code of spawned process: $value"
+exit $value


### PR DESCRIPTION
from: https://github.com/teamdable/vv-edge-player/pull/40#discussion_r818493335 

- player 의 경우 패키지를 추가했을 때 npm install 이 실패하면 실행시 오류가 발생한다.
- 설치 실패 즉시 재배포 해야하므로, github action UI 에서 확인하기 위해 exit code 를 relay 한다.

https://stackoverflow.com/a/23636473