### PR TITLE
alpha, beta, rc version 지원

### DIFF
--- a/install-check.sh
+++ b/install-check.sh
@@ -11,7 +11,7 @@ extract_version() {
 		echo "배포 대상 edge device의 version 파일을 읽어올 수 없습니다."
 		exit 1
 	fi
-	version=`echo $raw_version_data | sed 's/[^a0-9.]//g'`
+	version=`echo $raw_version_data | sed 's/[^abrc0-9.]//g'`
 	echo $version
 }
 


### PR DESCRIPTION
```
build & deploy Success
source version: 1.0.21, target version: 1.0.2a2
[err] target version과 source version이 일치하지않습니다
```
rc 버전을 지원하지않아서, 수정했습니다.